### PR TITLE
Add parameter resolver test

### DIFF
--- a/tests/utils/parameterResolver.test.ts
+++ b/tests/utils/parameterResolver.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { resolveEndpointParameters } from '../../src/utils/parameterResolver.js'
+
+const templateEndpoint = {
+  name: 'User Details',
+  url: 'https://api.example.com/users/{userId}?token={token}',
+  method: 'GET' as const,
+  headers: {
+    Authorization: 'Bearer {token}',
+    'X-User': '{userId}'
+  },
+  body: {
+    query: '{search}',
+    nested: { id: '{userId}' }
+  },
+  parameters: {
+    userId: '123',
+    token: 'abcd',
+    search: 'find'
+  }
+}
+
+describe('resolveEndpointParameters', () => {
+  it('replaces placeholders in url, headers and body', () => {
+    const resolved = resolveEndpointParameters(templateEndpoint)
+
+    expect(resolved.url).toBe('https://api.example.com/users/123?token=abcd')
+    expect(resolved.headers).toEqual({
+      Authorization: 'Bearer abcd',
+      'X-User': '123'
+    })
+    expect(resolved.body).toEqual({
+      query: 'find',
+      nested: { id: '123' }
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- add Vitest config
- test placeholder substitution for resolveEndpointParameters

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851db1fd29083338cdd27e33ead2047